### PR TITLE
Adding Access-Control-Request-Headers support

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+var accessControlRequestHeaders;
+
 var requestListener = function(details){
 	var flag = false,
 		rule = {
@@ -34,8 +36,6 @@ var responseListener = function(details){
 
 	if (accessControlRequestHeaders) {
 
-		console.log(accessControlRequestHeaders);
-
 		details.responseHeaders.push({"name": "Access-Control-Allow-Headers", "value": accessControlRequestHeaders});
 
 	}
@@ -52,8 +52,6 @@ chrome.runtime.onInstalled.addListener(function(){
 
 /*Icon change*/
 chrome.browserAction.onClicked.addListener(function(tab){
-
-	var accessControlRequestHeaders;
 	
 	if(localStorage.active === "true"){
 		localStorage.active = false;


### PR DESCRIPTION
To be full CORS compliant,  `Access-Control-Allow-Origin` isn't the only required response header, you also need to add `Access-Control-Request-Headers` matching all values (besides `accept`) in the `Access-Control-Request-Headers` request header.
