### PR TITLE
Allow CORS with Credentials

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,7 +31,7 @@ var responseListener = function(details){
 	var flag = false,
 	rule = {
 			"name": "Access-Control-Allow-Origin",
-			"value": "*"
+			"value": details.originUrl
 		};
 
 	for (var i = 0; i < details.responseHeaders.length; ++i) {


### PR DESCRIPTION
If you are using credentials, Access-Control-Allow-Origin can't be set to "*", it have to be set to exactly the requesting domain.
