### PR TITLE
deleted header for outside webiste

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,8 +4,7 @@ var exposedHeaders;
 var requestListener = function(details){
 	var flag = false,
 		rule = {
-			name: "Origin",
-			value: "http://evil.com/"
+			name: "Origin"
 		};
 	var i;
 


### PR DESCRIPTION
Website links headers to "http://evil.com", which should not be linked/included in the extension. Seems either a bug or a uncalled for include by the developer.