### PR TITLE
Removed the default 'http://evil.com' Origin override in the request.

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,21 +2,25 @@ var accessControlRequestHeaders;
 var exposedHeaders;
 
 var requestListener = function(details){
-	var flag = false,
-		rule = {
-			name: "Origin",
-			value: "http://evil.com/"
-		};
+	var flag = false;
+	// Specify a `name` and `value` property within `rule` to
+	// customize a request header. For instance, the commented
+	// out values will include in the header "Origin: 'https://my_changed_origin.com'"
+	var rule = null;
+	// var rule = {
+		// name: "Origin",
+		// value: "https://my_changed_origin.com"
+	// };
 	var i;
 
 	for (i = 0; i < details.requestHeaders.length; ++i) {
-		if (details.requestHeaders[i].name.toLowerCase() === rule.name.toLowerCase()) {
+		if (rule && details.requestHeaders[i].name.toLowerCase() === rule.name.toLowerCase()) {
 			flag = true;
 			details.requestHeaders[i].value = rule.value;
 			break;
 		}
 	}
-	if(!flag) details.requestHeaders.push(rule);
+	if(rule && !flag) details.requestHeaders.push(rule);
 	
 	for (i = 0; i < details.requestHeaders.length; ++i) {
 		if (details.requestHeaders[i].name.toLowerCase() === "access-control-request-headers") {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Allow-Control-Allow-Origin: *",
-	"version": "1.0.2",
-	"manifest_version": 2,
+	"version": "1.0.3",
+	"manifest_version": 3,
 	"description": "Allows to you request any site with ajax from any source. Adds to response 'Allow-Control-Allow-Origin: *' header",
 	"background": {
 		"scripts": ["background.js"]


### PR DESCRIPTION
Re #45 .

At my work, we use the `Origin` header to try and guess whether a full request/response is occurring over https or not. More generally, I think it's common to log non-sensitive headers for threat monitoring/analytics etc. For anyone not familiar with this extension, a large number of incoming requests from 'evil.com' can be very alarming! 

That said, I left the ability as a comment with how to enable - if people want to change the request origin, they should feel free to. But I don't think that should be happening for devs unknowingly. :)

@vitvad , there hasn't been much activity in this repo lately but I'd love if you could merge this in and get an update into the extension store (my understanding is existing users should get autoupdated?). Let me know if there's anything you'd need from me to make that easier. 🍻 