### PR TITLE
Matches Header Names Case Insensitively

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -89,7 +89,7 @@ var requestListener = function (details) {
     var flag = false;
 
     details.requestHeaders.forEach(function (header) {
-      if (header.name === rule.data.name) {
+      if (header.name.toLowerCase() === rule.data.name.toLowerCase()) {
         flag = true;
         if (rule.fn) {
           rule.fn.call(null, rule, header, details);
@@ -129,7 +129,7 @@ var responseListener = function (details) {
 
     details.responseHeaders.forEach(function (header) {
       // if rule exist in response - rewrite value
-      if (header.name === rule.data.name) {
+      if (header.name.toLowerCase() === rule.data.name.toLowerCase()) {
         flag = true;
         if (rule.fn) {
           rule.fn.call(null, rule.data, header, details);


### PR DESCRIPTION
- It doesn't look like this extension is being maintained anymore, but I
  added a small fix for myself and figured I would offer it upstream
- For anyone else here who doesn't own the extension in the chrome store,
  please note that it appears the chrome store extension is based off the
  dev branch of this repo
- The extension was matching the response rule header names exactly
  rather than ignoring the case and that was causing the * scoped
  origin header to be appended to nothing (with a comma) instead
  of replacing nothing